### PR TITLE
docs: add a link to the components helm charts

### DIFF
--- a/docs/source/additional/glossary.rst
+++ b/docs/source/additional/glossary.rst
@@ -8,7 +8,7 @@ Glossary
 
     Organization
         An organization represents an independant partner in the network. It has its own computing and storage resources.
-        
+
     Channel
-        A channel is a group of Substra organizations which operate on a common set of assets. Several channels can be built on top of a Substra network.
+        A channel is a group of Substra :term:`Organizations<Organization>`  which operate on a common set of assets. Several channels can be built on top of a Substra network.
 

--- a/docs/source/operations/backend/index.rst
+++ b/docs/source/operations/backend/index.rst
@@ -21,7 +21,7 @@ minio
 postgresql
     This is the database supporting the Backend.
     You should back up the data of this Pod.
-rabbitmq
+redis
     This is an organization-specific message broker to support `Celery`_ tasks.
 backend-events
     This component will consume events from the Orchestrator.
@@ -50,3 +50,11 @@ Communication
 
 The Backend should be able to reach its Orchestrator.
 If :term:`Organizations<Organization>` share :ref:`Models<concept_model>`, involved Backends must be able to communicate with each other.
+
+Helm chart
+==========
+
+We use Helm charts as a way to package our application deployments.
+If you want to deploy the Backend you can use the `Helm chart substra-backend`_.
+
+.. _Helm chart substra-backend: https://artifacthub.io/packages/helm/substra/substra-backend

--- a/docs/source/operations/orchestrator/index.rst
+++ b/docs/source/operations/orchestrator/index.rst
@@ -38,3 +38,11 @@ Storage
 
 The Orchestrator stores its data in a PostgreSQL database.
 Migrations are executed using a Kubernetes Job on installation and update (this relies on a Helm hook).
+
+Helm chart
+==========
+
+We use Helm charts as a way to package our application deployments.
+If you want to deploy the Orchestrator you can use the `Helm chart orchestrator`_.
+
+.. _Helm chart orchestrator: https://artifacthub.io/packages/helm/substra/orchestrator


### PR DESCRIPTION
I did some minor fixes and added links to ArtifactHUB  to let users know they can find charts information there.