### PR TITLE
docs: container build error logs are now accessible to end users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * fix: mlflow script
 * doc: add documentation on the execution steps in remote mode and the centralized strategy workflow (#173)
 * doc: remove download all examples button
+* doc: container build error logs are now accessible to end users
 
 ## [0.20.0]
 

--- a/docs/source/documentation/debug.rst
+++ b/docs/source/documentation/debug.rst
@@ -104,7 +104,7 @@ Accessing failed tasks logs
 
 Logs of tasks that were run on the deployed platform can be accessed under two conditions:
 
-* The task has failed and the `error_type` is an `EXECUTION_ERROR`.
+* The task has failed and the `error_type` is an `EXECUTION_ERROR` or a `BUILD_ERROR`.
 * The user belongs to a organization that has permissions to access the logs of this task.
 
 Logs of failed tasks can be accessed if the right permission is set on the dataset used in the task. Permissions are set when the dataset is created using the `logs_permission` field of the `DatasetSpec`. Permissions cannot be changed once the dataset is created.


### PR DESCRIPTION
Companion PRs:
- https://github.com/Substra/substra-backend/pull/483 (main PR)
- https://github.com/Substra/orchestrator/pull/38
- https://github.com/Substra/substra/pull/295
- https://github.com/Substra/substra-tests/pull/218
- https://github.com/Substra/substra-frontend/pull/116
- https://github.com/Substra/substra-documentation/pull/184 (this PR)

--- 

