### PR TITLE
feat: add python 3.10 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update the MNIST example to be easier to read (#208)
 - Move utils folder content in assets folder (#210)
 - Increase tocdepth in SDK API reference to display methods under Client (#219)
+- Update substratools Docker image name (#222)
 
 ## [0.22.0]
 

--- a/docs/source/substrafl_doc/substrafl_overview.rst
+++ b/docs/source/substrafl_doc/substrafl_overview.rst
@@ -22,7 +22,7 @@ Installation
 
 .. _installation:
 
-SubstraFL and Substra are compatible with Python versions 3.8 and 3.9 on both MacOS and Linux. For Windows users you can use the
+Substrafl and Substra are compatible with Python versions 3.8, 3.9 and 3.10 on both MacOS and Linux. For Windows users you can use the
 `Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/about>`_.
 
 To install SubstraFL run the following command:

--- a/examples/titanic_example/assets/algo_random_forest/predict/Dockerfile
+++ b/examples/titanic_example/assets/algo_random_forest/predict/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM ghcr.io/substra/substra-tools:0.18.0-nvidiacuda11.6.0-base-ubuntu20.04-python3.9
+FROM ghcr.io/substra/substra-tools:0.18.0-nvidiacuda11.8.0-base-ubuntu22.04-python3.9
 
 # install dependencies
 RUN pip3 install pandas numpy 'scikit-learn==0.24.2' pillow scipy keras

--- a/examples/titanic_example/assets/algo_random_forest/train/Dockerfile
+++ b/examples/titanic_example/assets/algo_random_forest/train/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM ghcr.io/substra/substra-tools:0.18.0-nvidiacuda11.6.0-base-ubuntu20.04-python3.9
+FROM ghcr.io/substra/substra-tools:0.18.0-nvidiacuda11.8.0-base-ubuntu22.04-python3.9
 
 # install dependencies
 RUN pip3 install pandas numpy 'scikit-learn==0.24.2' pillow scipy keras

--- a/examples/titanic_example/assets/metric/Dockerfile
+++ b/examples/titanic_example/assets/metric/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM ghcr.io/substra/substra-tools:0.18.0-nvidiacuda11.6.0-base-ubuntu20.04-python3.9
+FROM ghcr.io/substra/substra-tools:0.18.0-nvidiacuda11.8.0-base-ubuntu22.04-python3.9
 
 # install dependencies
 RUN pip3 install scikit-learn==1.0.2

--- a/substrafl_examples/get_started/torch_fedavg_assets/metric/Dockerfile
+++ b/substrafl_examples/get_started/torch_fedavg_assets/metric/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM ghcr.io/substra/substra-tools:0.18.0-nvidiacuda11.6.0-base-ubuntu20.04-python3.9
+FROM ghcr.io/substra/substra-tools:0.18.0-nvidiacuda11.8.0-base-ubuntu22.04-python3.9
 
 # install dependencies
 RUN pip3 install numpy==1.23.1 scikit-learn==1.1.1 torch==1.11.0

--- a/substrafl_examples/go_further/sklearn_fedavg_assets/metric/Dockerfile
+++ b/substrafl_examples/go_further/sklearn_fedavg_assets/metric/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM ghcr.io/substra/substra-tools:0.18.0-nvidiacuda11.6.0-base-ubuntu20.04-python3.9
+FROM ghcr.io/substra/substra-tools:0.18.0-nvidiacuda11.8.0-base-ubuntu22.04-python3.9
 
 # install dependencies
 RUN pip3 install numpy==1.23.1 scikit-learn==1.1.1


### PR DESCRIPTION
## Summary

Update substratools Docker image to the new one using new Ubuntu LTS (22.04) and supporting Python 3.10.

## Companion PR

- https://github.com/Substra/substra/pull/316
- https://github.com/Substra/substra-tools/pull/68
- https://github.com/Substra/substrafl/pull/49
- https://github.com/Substra/substra-tests/pull/230