### PR TITLE
feat: Add contributing guide & code of conduct

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,20 @@
+This is a file of people that have made significant contributions to the Substra project. It is sorted in chronological order. Please include your contribution at the bottom of this document in the following format : name (N), email (E), description of work (W) and date (D).
+
+To have your contribution listed, your work must meet the minimum [threshold of originality](https://en.wikipedia.org/wiki/Threshold_of_originality), which will be evaluated by the maintainers of repository.
+
+Thank you for your contribution, your work is greatly appreciated !
+
+—-- Example —--
+
+- N: John Doe
+- E: john.doe@owkin.com
+- W: Integrated new FL strategy
+- D: 02/02/2023
+
+---
+
+Copyright (c) Owkin. All rights reserved.
+
+All other contributions:
+Copyright (c) to the respective contributors.
+All rights reserved.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,8 +13,8 @@ Thank you for your contribution, your work is greatly appreciated !
 
 ---
 
-Copyright (c) Owkin. All rights reserved.
+Copyright (c) 2018-present Owkin Inc. All rights reserved.
 
 All other contributions:
-Copyright (c) to the respective contributors.
+Copyright (c) 2023 to the respective contributors.
 All rights reserved.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
-This is a file of people that have made significant contributions to the Substra project. It is sorted in chronological order. Please include your contribution at the bottom of this document in the following format : name (N), email (E), description of work (W) and date (D).
+This is a file of people that have made significant contributions to the Substra documentation. It is sorted in chronological order. Please include your contribution at the bottom of this document in the following format : name (N), email (E), description of work (W) and date (D).
 
-To have your contribution listed, your work must meet the minimum [threshold of originality](https://en.wikipedia.org/wiki/Threshold_of_originality), which will be evaluated by the maintainers of repository.
+To have your contribution listed, your work must meet the minimum [threshold of originality](https://en.wikipedia.org/wiki/Threshold_of_originality), which will be evaluated by the maintainers of the repository.
 
 Thank you for your contribution, your work is greatly appreciated !
 

--- a/docs/source/contributing/code-of-conduct.rst
+++ b/docs/source/contributing/code-of-conduct.rst
@@ -1,5 +1,5 @@
 ***************************************
-Contributor Covenant Code of Conduct
+Code of Conduct
 ***************************************
 
 Our Pledge
@@ -26,14 +26,13 @@ include:
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-    advances
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-    address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-    professional setting
+* Publishing others' private information, such as a physical or electronic address, 
+without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional 
+setting
 
 Our Responsibilities
 ====================
@@ -62,7 +61,7 @@ Enforcement
 ===========
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting opensource@github.com, which is a shared team inbox. If the incident involves someone who receives that shared inbox, you can contact an individual maintainer (@bkeepers or @nayafia) at `GitHub username` + `@github.com`. All
+reported by contacting squad-federated-learning@owkin.com, which is a shared team inbox. If the incident involves someone who receives that shared inbox, you can contact an individual maintainer. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -75,5 +74,4 @@ members of the project's leadership.
 Attribution
 ===========
 
-This Code of Conduct is adapted from the `Contributor Covenant <https://contributor-covenant.org>`_, version 1.4,
-available at https://contributor-covenant.org/version/1/4
+This Code of Conduct is adapted from the `Contributor Covenant <https://contributor-covenant.org/version/1/4>`_, version 1.4.

--- a/docs/source/contributing/code-of-conduct.rst
+++ b/docs/source/contributing/code-of-conduct.rst
@@ -1,0 +1,81 @@
+***************************************
+Contributor Covenant Code of Conduct
+***************************************
+
+Our Pledge
+==========
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+Our Standards
+=============
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+    advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+    address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+    professional setting
+
+Our Responsibilities
+====================
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Scope
+=====
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+Enforcement
+===========
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting opensource@github.com, which is a shared team inbox. If the incident involves someone who receives that shared inbox, you can contact an individual maintainer (@bkeepers or @nayafia) at `GitHub username` + `@github.com`. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+Attribution
+===========
+
+This Code of Conduct is adapted from the `Contributor Covenant`_, version 1.4,
+available at https://contributor-covenant.org/version/1/4
+
+.. _Contributor Covenant : https://contributor-covenant.org

--- a/docs/source/contributing/code-of-conduct.rst
+++ b/docs/source/contributing/code-of-conduct.rst
@@ -29,10 +29,8 @@ Examples of unacceptable behavior by participants include:
 * The use of sexualized language or imagery and unwelcome sexual attention or advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, 
-without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional 
-setting
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
 Our Responsibilities
 ====================

--- a/docs/source/contributing/code-of-conduct.rst
+++ b/docs/source/contributing/code-of-conduct.rst
@@ -75,7 +75,5 @@ members of the project's leadership.
 Attribution
 ===========
 
-This Code of Conduct is adapted from the `Contributor Covenant`_, version 1.4,
+This Code of Conduct is adapted from the `Contributor Covenant <https://contributor-covenant.org>`_, version 1.4,
 available at https://contributor-covenant.org/version/1/4
-
-.. _Contributor Covenant : https://contributor-covenant.org

--- a/docs/source/contributing/contributing-guide.rst
+++ b/docs/source/contributing/contributing-guide.rst
@@ -2,7 +2,7 @@
 Contributing Guide
 ************************
 
-Thanks for checking out the contributing guide. Substra warmly welcomes contributions !
+Thanks for checking out the contributing guide. Substra warmly welcomes contributions!
 
 Ground rules & expectations
 ===========================

--- a/docs/source/contributing/contributing-guide.rst
+++ b/docs/source/contributing/contributing-guide.rst
@@ -8,7 +8,7 @@ Ground rules & expectations
 ===========================
 
 * Be kind and thoughtful in your conversations around this project. We all come from different backgrounds and projects, which means we likely have different perspectives on how things should be done. Try to listen to others rather than convince them that your way is correct.
-* Substra has a :doc: `Contributor Code of Conduct </contributing/code-of-conduct>`. By participating in this project, you agree to abide by its terms.
+* Substra has a :doc:`Contributor Code of Conduct </contributing/code-of-conduct>`. By participating in this project, you agree to abide by its terms.
 
 How to contribute
 =================
@@ -22,11 +22,8 @@ A pull request doesn't have to represent finished work. You can open a pull requ
 
 Here's how to submit a pull request:
 
-* **`Fork the repository`_** and clone it locally. Connect your local to the original "upstream" repository by adding it as a remote. Pull in changes from "upstream" often so that you stay up to date so that when you submit your pull request, merge conflicts will be less likely. (See more detailed instructions `here`_.)
-.. _Fork the repository : https://guides.github.com/activities/forking/
-.. _Here : https://help.github.com/articles/syncing-a-fork/
-* **`Create a branch`_** for your edits.
-.. _Create a branch : https://guides.github.com/introduction/flow/
+* **`Fork the repository <https://guides.github.com/activities/forking/>`_** and clone it locally. Connect your local to the original "upstream" repository by adding it as a remote. Pull in changes from "upstream" often so that you stay up to date so that when you submit your pull request, merge conflicts will be less likely. (See more detailed instructions `here <https://help.github.com/articles/syncing-a-fork/>`_.)
+* **`Create a branch <https://guides.github.com/introduction/flow/>`_** for your edits.
 * **Sign off** your commits.
 * **Test your changes.** Please ensure that your contribution passes all tests if you open a pull request. If there are test failures, you will need to address them before we can merge your contribution.
 * **Contribute in the style of the project** to the best of your abilities. This may mean using indents, semi-colons or comments differently than you would in your own repository, but makes it easier for us to merge, others to understand and maintain in the future.
@@ -34,8 +31,7 @@ Here's how to submit a pull request:
 Sign Off
 ========
 
-For compliance purposes, `Developer Certificate of Origin (DCO) on Pull Requests`_ is activated on the repo.
-.. _Developer Certificate of Origin (DCO) on Pull Requests: https://github.com/apps/dco
+For compliance purposes, `Developer Certificate of Origin (DCO) on Pull Requests <https://github.com/apps/dco>`_ is activated on the repo.
 
 .. code-block:: bash
 
@@ -56,5 +52,4 @@ Wherever possible, do not take these conversations to private channels, includin
 Attribution
 ===========
 
-This guide follows guidelines from `opensource.guide`_
-.. _opensource.guide : https://github.com/github/opensource.guide
+This guide follows guidelines from `opensource.guide <https://github.com/github/opensource.guide>`_

--- a/docs/source/contributing/contributing-guide.rst
+++ b/docs/source/contributing/contributing-guide.rst
@@ -1,0 +1,60 @@
+************************
+Contributing Guide
+************************
+
+Thanks for checking out the contributing guide. Substra warmly welcomes contributions !
+
+Ground rules & expectations
+===========================
+
+* Be kind and thoughtful in your conversations around this project. We all come from different backgrounds and projects, which means we likely have different perspectives on how things should be done. Try to listen to others rather than convince them that your way is correct.
+* Substra has a :doc: `Contributor Code of Conduct </contributing/code-of-conduct>`. By participating in this project, you agree to abide by its terms.
+
+How to contribute
+=================
+
+You should usually open a pull request in the following situations:
+
+* Submit trivial fixes (for example, a typo, a broken link or an obvious error)
+* Start work on a contribution that was already asked for, or that you've already discussed, in an issue
+
+A pull request doesn't have to represent finished work. You can open a pull request early on, so others can watch or give feedback on your progress. Just open it as a "draft". You can always add more commits later.
+
+Here's how to submit a pull request:
+
+* **`Fork the repository`_** and clone it locally. Connect your local to the original "upstream" repository by adding it as a remote. Pull in changes from "upstream" often so that you stay up to date so that when you submit your pull request, merge conflicts will be less likely. (See more detailed instructions `here`_.)
+.. _Fork the repository : https://guides.github.com/activities/forking/
+.. _Here : https://help.github.com/articles/syncing-a-fork/
+* **`Create a branch`_** for your edits.
+.. _Create a branch : https://guides.github.com/introduction/flow/
+* **Sign off** your commits.
+* **Test your changes.** Please ensure that your contribution passes all tests if you open a pull request. If there are test failures, you will need to address them before we can merge your contribution.
+* **Contribute in the style of the project** to the best of your abilities. This may mean using indents, semi-colons or comments differently than you would in your own repository, but makes it easier for us to merge, others to understand and maintain in the future.
+
+Sign Off
+========
+
+For compliance purposes, `Developer Certificate of Origin (DCO) on Pull Requests`_ is activated on the repo.
+.. _Developer Certificate of Origin (DCO) on Pull Requests: https://github.com/apps/dco
+
+.. code-block:: bash
+
+    In practice, you must add a ``Signed-off-by:`` message at the end of every commit:
+
+    This is my commit message
+
+Signed-off-by: Random J Developer <random@developer.example.org>
+Add ``-s`` flag to add it automatically: ``git commit -s -m 'This is my commit message'``.
+
+Community
+=========
+
+Discussions about Substra take place on this repository's Issues and Pull Requests sections. Anybody is welcome to join these conversations.
+
+Wherever possible, do not take these conversations to private channels, including contacting the maintainers directly. Keeping communication public means everybody can benefit and learn from the conversation.
+
+Attribution
+===========
+
+This guide follows guidelines from `opensource.guide`_
+.. _opensource.guide : https://github.com/github/opensource.guide

--- a/docs/source/contributing/contributing-guide.rst
+++ b/docs/source/contributing/contributing-guide.rst
@@ -7,13 +7,14 @@ Thanks for checking out the contributing guide. Substra warmly welcomes contribu
 Ground rules & expectations
 ===========================
 
-* Be kind and thoughtful in your conversations around this project. We all come from different backgrounds and projects, which means we likely have different perspectives on how things should be done. Try to listen to others rather than convince them that your way is correct.
-* Substra has a :doc:`Contributor Code of Conduct </contributing/code-of-conduct>`. By participating in this project, you agree to abide by its terms.
+Be kind and thoughtful in your conversations around this project. We all come from different backgrounds and projects, which means we likely have different perspectives on how things should be done. Try to listen to others rather than convince them that your way is correct.
 
-Who are contributors ?
+Substra has a :doc:`Contributor Code of Conduct </contributing/code-of-conduct>`. By participating in this project, you agree to abide by its terms.
+
+Who are contributors?
 ======================
 
-Contributors are any person that have contributed to the code. It does not matter whether it's a typo fix or 10k lines of code. Making a contribution however does not automatically entitle you to copyright over that code. For copyright the contribution must be significant enough meet the `threshold of originality <https://en.wikipedia.org/wiki/Threshold_of_originality>`, which basically means that your code is somewhat unique and non-generic. Fixing a typo does not give you access to copyright over that word or sentence.
+Contributors are any person that have contributed to the code. It does not matter whether it's a typo fix or 10k lines of code. Making a contribution however does not automatically entitle you to copyright over that code. For copyright the contribution must be significant enough meet the `threshold of originality <https://en.wikipedia.org/wiki/Threshold_of_originality>`_, which basically means that your code is somewhat unique and non-generic. Fixing a typo does not give you access to copyright over that word or sentence.
 
 How to contribute
 =================
@@ -27,7 +28,7 @@ A pull request doesn't have to represent finished work. You can open a pull requ
 
 Here's how to submit a pull request:
 
-* `Fork the repository <https://guides.github.com/activities/forking/>`_ and clone it locally. Connect your local to the original "upstream" repository by adding it as a remote. Pull in changes from "upstream" often so that you stay up to date so that when you submit your pull request, merge conflicts will be less likely. (See more detailed instructions `here <https://help.github.com/articles/syncing-a-fork/>`_.)
+* `Fork the repository <https://guides.github.com/activities/forking/>`_ and clone it locally. Connect your local to the original "upstream" repository by adding it as a remote. Pull in changes from "upstream" often so that you stay up to date so that when you submit your pull request, merge conflicts will be less likely. (See more detailed instructions `here <https://help.github.com/articles/syncing-a-fork/>`_.
 * `Create a branch <https://guides.github.com/introduction/flow/>`_ for your edits.
 * **Sign off** your commits.
 * **Test your changes.** Please ensure that your contribution passes all tests if you open a pull request. If there are test failures, you will need to address them before we can merge your contribution.
@@ -48,10 +49,10 @@ In practice, you must add a ``Signed-off-by:`` message at the end of every commi
 
 Add ``-s`` flag to add it automatically: ``git commit -s -m 'This is my commit message'``.
 
-Community
+`Community </additional/community>`
 =========
 
-Discussions about Substra take place on this repository's Issues and Pull Requests sections. Anybody is welcome to join these conversations.
+Discussions about Substra take place on the repositories' Issues and Pull Requests sections and on Slack. Anybody is welcome to join these conversations.
 
 Wherever possible, do not take these conversations to private channels, including contacting the maintainers directly. Keeping communication public means everybody can benefit and learn from the conversation.
 

--- a/docs/source/contributing/contributing-guide.rst
+++ b/docs/source/contributing/contributing-guide.rst
@@ -49,8 +49,8 @@ In practice, you must add a ``Signed-off-by:`` message at the end of every commi
 
 Add ``-s`` flag to add it automatically: ``git commit -s -m 'This is my commit message'``.
 
-`Community </additional/community>`
-=========
+:doc:`Community </additional/community>`
+========================================
 
 Discussions about Substra take place on the repositories' Issues and Pull Requests sections and on Slack. Anybody is welcome to join these conversations.
 

--- a/docs/source/contributing/contributing-guide.rst
+++ b/docs/source/contributing/contributing-guide.rst
@@ -10,6 +10,11 @@ Ground rules & expectations
 * Be kind and thoughtful in your conversations around this project. We all come from different backgrounds and projects, which means we likely have different perspectives on how things should be done. Try to listen to others rather than convince them that your way is correct.
 * Substra has a :doc:`Contributor Code of Conduct </contributing/code-of-conduct>`. By participating in this project, you agree to abide by its terms.
 
+Who are contributors ?
+======================
+
+Contributors are any person that have contributed to the code. It does not matter whether it's a typo fix or 10k lines of code. Making a contribution however does not automatically entitle you to copyright over that code. For copyright the contribution must be significant enough meet the `threshold of originality <https://en.wikipedia.org/wiki/Threshold_of_originality>`, which basically means that your code is somewhat unique and non-generic. Fixing a typo does not give you access to copyright over that word or sentence.
+
 How to contribute
 =================
 
@@ -27,6 +32,7 @@ Here's how to submit a pull request:
 * **Sign off** your commits.
 * **Test your changes.** Please ensure that your contribution passes all tests if you open a pull request. If there are test failures, you will need to address them before we can merge your contribution.
 * **Contribute in the style of the project** to the best of your abilities. This may mean using indents, semi-colons or comments differently than you would in your own repository, but makes it easier for us to merge, others to understand and maintain in the future.
+* **Add yourself to the contributors**. If you made a significant contribution, don't forget to add yourself to the CONTRIBUTORS.md file of the repo by putting your name and a small description of your work. 
 
 Sign Off
 ========

--- a/docs/source/contributing/contributing-guide.rst
+++ b/docs/source/contributing/contributing-guide.rst
@@ -22,8 +22,8 @@ A pull request doesn't have to represent finished work. You can open a pull requ
 
 Here's how to submit a pull request:
 
-* `**Fork the repository** <https://guides.github.com/activities/forking/>`_ and clone it locally. Connect your local to the original "upstream" repository by adding it as a remote. Pull in changes from "upstream" often so that you stay up to date so that when you submit your pull request, merge conflicts will be less likely. (See more detailed instructions `here <https://help.github.com/articles/syncing-a-fork/>`_.)
-* `**Create a branch** <https://guides.github.com/introduction/flow/>`_ for your edits.
+* `Fork the repository <https://guides.github.com/activities/forking/>`_ and clone it locally. Connect your local to the original "upstream" repository by adding it as a remote. Pull in changes from "upstream" often so that you stay up to date so that when you submit your pull request, merge conflicts will be less likely. (See more detailed instructions `here <https://help.github.com/articles/syncing-a-fork/>`_.)
+* `Create a branch <https://guides.github.com/introduction/flow/>`_ for your edits.
 * **Sign off** your commits.
 * **Test your changes.** Please ensure that your contribution passes all tests if you open a pull request. If there are test failures, you will need to address them before we can merge your contribution.
 * **Contribute in the style of the project** to the best of your abilities. This may mean using indents, semi-colons or comments differently than you would in your own repository, but makes it easier for us to merge, others to understand and maintain in the future.

--- a/docs/source/contributing/contributing-guide.rst
+++ b/docs/source/contributing/contributing-guide.rst
@@ -22,8 +22,8 @@ A pull request doesn't have to represent finished work. You can open a pull requ
 
 Here's how to submit a pull request:
 
-* **`Fork the repository <https://guides.github.com/activities/forking/>`_** and clone it locally. Connect your local to the original "upstream" repository by adding it as a remote. Pull in changes from "upstream" often so that you stay up to date so that when you submit your pull request, merge conflicts will be less likely. (See more detailed instructions `here <https://help.github.com/articles/syncing-a-fork/>`_.)
-* **`Create a branch <https://guides.github.com/introduction/flow/>`_** for your edits.
+* `**Fork the repository** <https://guides.github.com/activities/forking/>`_ and clone it locally. Connect your local to the original "upstream" repository by adding it as a remote. Pull in changes from "upstream" often so that you stay up to date so that when you submit your pull request, merge conflicts will be less likely. (See more detailed instructions `here <https://help.github.com/articles/syncing-a-fork/>`_.)
+* `**Create a branch** <https://guides.github.com/introduction/flow/>`_ for your edits.
 * **Sign off** your commits.
 * **Test your changes.** Please ensure that your contribution passes all tests if you open a pull request. If there are test failures, you will need to address them before we can merge your contribution.
 * **Contribute in the style of the project** to the best of your abilities. This may mean using indents, semi-colons or comments differently than you would in your own repository, but makes it easier for us to merge, others to understand and maintain in the future.
@@ -33,13 +33,13 @@ Sign Off
 
 For compliance purposes, `Developer Certificate of Origin (DCO) on Pull Requests <https://github.com/apps/dco>`_ is activated on the repo.
 
+In practice, you must add a ``Signed-off-by:`` message at the end of every commit:
+
 .. code-block:: bash
 
-    In practice, you must add a ``Signed-off-by:`` message at the end of every commit:
-
     This is my commit message
+    Signed-off-by: Random J Developer <random@developer.example.org>
 
-Signed-off-by: Random J Developer <random@developer.example.org>
 Add ``-s`` flag to add it automatically: ``git commit -s -m 'This is my commit message'``.
 
 Community

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -90,6 +90,8 @@ Some quick links:
    :caption: Contributing to Substra
    :hidden:
 
+   contributing/contributing-guide.rst
+   contributing/code-of-conduct.rst
    contributing/components.rst
    contributing/getting-started.rst
 


### PR DESCRIPTION
Signed-off-by: Milouu <milan.roustan@owkin.com>

Add a contributing guide & code of conduct to the documentation. We add these in the documentation to centralize it. We will then be able to create CONTRIBUTING.md & CODE_OF_CONDUCT.md files in the other repositories referencing these pages.