### PR TITLE
doc: how to deploy the frontend

### DIFF
--- a/docs/source/operations/howto/backend-deployment.rst
+++ b/docs/source/operations/howto/backend-deployment.rst
@@ -1,6 +1,6 @@
-*****************************
-How to deploy Substra Backend
-*****************************
+*********************************
+How to deploy the Substra backend
+*********************************
 
 This guide shows you how to deploy the backend component of Substra.
 

--- a/docs/source/operations/howto/frontend-deployment.rst
+++ b/docs/source/operations/howto/frontend-deployment.rst
@@ -1,0 +1,49 @@
+**********************************
+How to deploy the Substra frontend
+**********************************
+
+This page contains info about deploying the frontend component of Substra.
+
+Prerequisites
+=============
+
+The Substra frontend is a standalone Helm chart that only needs to be told under what URL the backend API is to be contacted.
+
+This means you first need :doc:`a running backend deployment <backend-deployment>`, which must accept connections on an accessible URL.
+
+You'll need to tell the backend to set the proper headers for cross-origin resources, in the **backend values**:
+
+.. code-block:: yaml
+
+   config:
+     CORS_ORIGIN_WHITELIST: '["your.frontend.url"]' # this is a string parsed as a JSON list
+     CORS_ALLOW_CREDENTIALS: True
+
+Preparing your Helm values
+==========================
+
+You'll need to specify the backend API url:
+
+.. code-block:: yaml
+
+   api:
+     url: "https://your.backend.url"
+
+Expose the service with the included ingress:
+
+.. code-block:: yaml
+   :caption: This assumes you have an ingress controller and ``connect-frontend-tls`` contains a certificate.
+
+   ingress:
+     hosts:
+       - host: your.frontend.url
+         paths: ['/']
+     tls:
+       - hosts:
+         - your.frontend.url
+         secretName: connect-frontend-tls
+
+Deploy the Chart
+================
+
+Deploy with ``helm install`` as normal. Validate with a web browser.

--- a/docs/source/operations/howto/frontend-deployment.rst
+++ b/docs/source/operations/howto/frontend-deployment.rst
@@ -32,7 +32,6 @@ You'll need to specify the backend API url:
 Expose the service with the included ingress:
 
 .. code-block:: yaml
-   :caption: This assumes you have an ingress controller and ``connect-frontend-tls`` contains a certificate.
 
    ingress:
      hosts:
@@ -41,7 +40,10 @@ Expose the service with the included ingress:
      tls:
        - hosts:
          - your.frontend.url
-         secretName: connect-frontend-tls
+         secretName: substra-frontend-tls
+
+.. note::
+   This assumes you have an ingress controller and ``substra-frontend-tls`` contains a certificate.
 
 Deploy the Chart
 ================

--- a/docs/source/operations/howto/frontend-deployment.rst
+++ b/docs/source/operations/howto/frontend-deployment.rst
@@ -22,6 +22,8 @@ You'll need to tell the backend to set the proper headers for cross-origin resou
 Preparing your Helm values
 ==========================
 
+Like with the backend, create a file for your values, say ``frontend-values.yaml``.
+
 You'll need to specify the backend API url:
 
 .. code-block:: yaml
@@ -48,4 +50,10 @@ Expose the service with the included ingress:
 Deploy the Chart
 ================
 
-Deploy with ``helm install`` as normal. Validate with a web browser.
+Deploy with Helm, like the backend:
+
+   .. code-block:: bash
+
+      helm install RELEASE-NAME substra/substra-frontend --version VERSION --values frontend-values.yaml
+
+Validate with a web browser (the initial users to log in as are set up in the backend values).


### PR DESCRIPTION
Add a page with instructions on how to deploy the frontend.

I didn't restate all the instructions on Helm and so, since they are already in the backend and the orchestrator. Maybe I ought to?

Another thought: many problems encountered when deploying the frontend are routing problems, which aren't covered here (set up an ingress controller, set up a way to generate certificates). It's not our job to document this stuff but it might be helpful to people who don't know much about Kubernetes and·or trafic routing.