### PR TITLE
chore: update k3-create.sh

### DIFF
--- a/docs/source/contributing/local-deployment/k3-create.sh
+++ b/docs/source/contributing/local-deployment/k3-create.sh
@@ -10,7 +10,7 @@ fi
 k3d cluster delete || echo 'No cluster'
 mkdir -p /tmp/org-1
 mkdir -p /tmp/org-2
-k3d cluster create --api-port 127.0.0.1:6443 -p 80:80@loadbalancer -p 443:443@loadbalancer --k3s-arg "--no-deploy=traefik,metrics-server@server:*" --volume /tmp/org-1:/tmp/org-1 --volume /tmp/org-2:/tmp/org-2
+k3d cluster create --api-port 127.0.0.1:6443 -p 80:80@loadbalancer -p 443:443@loadbalancer --k3s-arg "--disable=traefik,metrics-server@server:*" --volume /tmp/org-1:/tmp/org-1 --volume /tmp/org-2:/tmp/org-2
 
 # Patch and install nginx-ingress
 curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml > /tmp/deploy.yaml


### PR DESCRIPTION
I am encountering this error:

```
INFO[0002] Starting Node 'k3d-k3s-default-server-0'     
WARN[0003] warning: encountered fatal log from node k3d-k3s-default-server-0 (retrying 0/10): ctime="2023-02-23T15:25:56Z" level=fatal msg="no-deploy flag is deprecated. Use --disable instead." 
[...]
WARN[0008] warning: encountered fatal log from node k3d-k3s-default-server-0 (retrying 9/10): ctime="2023-02-23T15:26:01Z" level=fatal msg="no-deploy flag is deprecated. Use --disable instead." 
ERRO[0008] Failed Cluster Start: Failed to start server k3d-k3s-default-server-0: Node k3d-k3s-default-server-0 failed to get ready: error waiting for log line `k3s is up and running` from node 'k3d-k3s-default-server-0': stopped returning log lines: node k3d-k3s-default-server-0 is running=true in status=restarting 
ERRO[0008] Failed to create cluster >>> Rolling Back    
INFO[0008] Deleting cluster 'k3s-default'               
INFO[0008] Deleting cluster network 'k3d-k3s-default'   
INFO[0009] Deleting 1 attached volumes...               
FATA[0009] Cluster creation FAILED, all changes have been rolled back! 
```

This change seems to fix the problem. I didn't look into it any further.