### PR TITLE
fix: previous releases links

### DIFF
--- a/docs/source/additional/releases.yaml
+++ b/docs/source/additional/releases.yaml
@@ -60,19 +60,19 @@ releases:
         link: https://github.com/Substra/substra-tools/releases/tag/0.20.0
       substra-backend:
         version: 0.34.1
-        link: https://github.com/Substra/substra-backend/releases/tag/0.34.0
+        link: https://github.com/Substra/substra-backend/releases/tag/0.34.1
         helm:
           version: 22.2.4
           link: https://artifacthub.io/packages/helm/substra/substra-backend/22.2.4
       orchestrator:
         version: 0.31.1
-        link: https://github.com/Substra/orchestrator/releases/tag/0.31.0
+        link: https://github.com/Substra/orchestrator/releases/tag/0.31.1
         helm:
           version: 7.4.8
           link: https://artifacthub.io/packages/helm/substra/orchestrator/7.4.8
       substra-frontend:
         version: 0.38.1
-        link: https://github.com/Substra/substra-frontend/releases/tag/0.38.0
+        link: https://github.com/Substra/substra-frontend/releases/tag/0.38.1
         helm:
           version: 1.0.11
           link: https://artifacthub.io/packages/helm/substra/substra-frontend/1.0.11
@@ -127,7 +127,7 @@ releases:
     components:
       substrafl:
         version: 0.30.2
-        link: https://github.com/Substra/substrafl/releases/tag/0.30
+        link: https://github.com/Substra/substrafl/releases/tag/0.30.2
       substra:
         version: 0.38.2
         link: https://github.com/Substra/substra/releases/tag/0.38.2


### PR DESCRIPTION
# Description

Some tag links for the previous releases do not point to the correct tag.