### PR TITLE
fix: mock torch

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -265,16 +265,9 @@ sys.path.append(os.path.abspath("./_ext"))
 extensions.append("compatibilitytable")
 
 todo_include_todos = False
+
 autodoc_mock_imports = ["torch"]
 
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3", None),
-    "numpy": ("https://numpy.org/doc/stable/", None),
-    "pandas": ("https://pandas.pydata.org/docs/", None),
-    "torch": ("https://pytorch.org/docs/stable/", None),
-}
-
-autodoc_typehints = "both"
 
 ################
 # Substrafl API

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -265,6 +265,7 @@ sys.path.append(os.path.abspath("./_ext"))
 extensions.append("compatibilitytable")
 
 todo_include_todos = False
+autodoc_mock_imports = ["torch"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
@@ -300,7 +301,6 @@ napoleon_numpy_docstring = False
 # Remove the prompt when copying examples
 copybutton_prompt_text = ">>> "
 
-autodoc_mock_imports = ["torch"]
 
 # As we defined the type of our args, auto doc is trying to find a link to a
 # documentation for each type specified

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -270,6 +270,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),
+    "torch": ("https://pytorch.org/docs/docs/", None),
 }
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -245,7 +245,6 @@ release = _doc_version
 # ones.
 extensions = ["sphinx_gallery.gen_gallery"]
 
-
 extensions.extend(
     [
         "sphinx.ext.intersphinx",
@@ -300,6 +299,8 @@ napoleon_numpy_docstring = False
 
 # Remove the prompt when copying examples
 copybutton_prompt_text = ">>> "
+
+autodoc_mock_imports = ["torch"]
 
 # As we defined the type of our args, auto doc is trying to find a link to a
 # documentation for each type specified
@@ -388,12 +389,14 @@ sphinx_gallery_conf = {
     "reference_url": {"Substra": None},
     "examples_dirs": ["../../examples", "../../substrafl_examples"],
     "gallery_dirs": ["auto_examples", "substrafl_doc/examples"],
-    "subsection_order": ExplicitOrder([
-        "../../examples/titanic_example",
-        "../../examples/diabetes_example",
-        "../../substrafl_examples/get_started",
-        "../../substrafl_examples/go_further",
-    ]),
+    "subsection_order": ExplicitOrder(
+        [
+            "../../examples/titanic_example",
+            "../../examples/diabetes_example",
+            "../../substrafl_examples/get_started",
+            "../../substrafl_examples/go_further",
+        ]
+    ),
     "download_all_examples": False,
     "filename_pattern": "/run_",
     "binder": {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -270,7 +270,6 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),
-    "torch": ("https://pytorch.org/docs/master/", None),
 }
 
 
@@ -303,6 +302,8 @@ copybutton_prompt_text = ">>> "
 # As we defined the type of our args, auto doc is trying to find a link to a
 # documentation for each type specified
 # The following elements are the link that auto doc were not able to do
+autodoc_mock_imports = ["torch"]
+
 nitpick_ignore = [
     ("py:class", "pydantic.main.BaseModel"),
     ("py:class", "torch.nn.modules.module.Module"),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -266,7 +266,12 @@ extensions.append("compatibilitytable")
 
 todo_include_todos = False
 
-autodoc_mock_imports = ["torch"]
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+    "torch": ("https://pytorch.org/docs/master/", None),
+}
 
 
 ################

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -303,7 +303,6 @@ copybutton_prompt_text = ">>> "
 # As we defined the type of our args, auto doc is trying to find a link to a
 # documentation for each type specified
 # The following elements are the link that auto doc were not able to do
-autodoc_mock_imports = ["torch"]
 
 nitpick_ignore = [
     ("py:class", "pydantic.main.BaseModel"),
@@ -312,7 +311,26 @@ nitpick_ignore = [
     ("py:class", "torch.optim.optimizer.Optimizer"),
     ("py:class", "torch.optim.lr_scheduler._LRScheduler"),
     ("py:class", "torch.utils.data.dataset.Dataset"),
-    ("py:class", "torch.device"),
+    ("py:class", "torch.nn.modules.module.T"),
+    ("py:class", "string"),
+    ("py:class", "Module"),
+    ("py:class", "optional"),
+    ("py:class", "Dropout"),
+    ("py:class", "BatchNorm"),
+    ("py:class", "torch.utils.hooks.RemovableHandle"),
+    ("py:class", "torch.nn.Parameter"),
+    ("py:class", "Parameter"),
+    ("py:class", "Tensor"),
+    ("py:attr", "persistent"),
+    ("py:attr", "grad_input"),
+    ("py:attr", "strict"),
+    ("py:attr", "grad_output"),
+    ("py:attr", "requires_grad"),
+    ("py:attr", "device"),
+    ("py:attr", "non_blocking"),
+    ("py:attr", "dst_type"),
+    ("py:attr", "dtype"),
+    ("py:attr", "device"),
     ("py:class", "substra.sdk.schemas.Permissions"),
     ("py:class", "substra.Client"),
     ("py:class", "substra.sdk.client.Client"),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -270,7 +270,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),
-    "torch": ("https://pytorch.org/docs/docs/", None),
+    "torch": ("https://pytorch.org/docs/stable/", None),
 }
 
 


### PR DESCRIPTION
Mock torch does not work here (as done in substrafl) for an obscure reason...

The only way found was to ignore manually all warning. Sorry for the ugly PR...