### PR TITLE
docs: external postgres

### DIFF
--- a/docs/source/operations/howto/existing-volumes.rst
+++ b/docs/source/operations/howto/existing-volumes.rst
@@ -17,7 +17,7 @@ Backend values:
      persistence:
        servermedias:
          existingClaim: "serverPVC"
-   postgresql:
+   integrated-postgresql:
      primary:
        persistence:
          existingClaim: "psqlPVC"
@@ -36,7 +36,7 @@ Orchestrator values (in standalone mode, which is the default):
 
 .. code-block:: yaml
 
-   postgresql:
+   integrated-postgresql:
      primary:
        persistence:
          existingClaim: "orcpsqlPVC"

--- a/docs/source/operations/howto/existing-volumes.rst
+++ b/docs/source/operations/howto/existing-volumes.rst
@@ -17,7 +17,7 @@ Backend values:
      persistence:
        servermedias:
          existingClaim: "serverPVC"
-   integrated-postgresql:
+   postgresql:
      primary:
        persistence:
          existingClaim: "psqlPVC"
@@ -36,7 +36,7 @@ Orchestrator values (in standalone mode, which is the default):
 
 .. code-block:: yaml
 
-   integrated-postgresql:
+   postgresql:
      primary:
        persistence:
          existingClaim: "orcpsqlPVC"

--- a/docs/source/operations/howto/external-database.rst
+++ b/docs/source/operations/howto/external-database.rst
@@ -4,27 +4,42 @@ Use an external database
 
 By default, Substra components use their own integrated postgres databases (one per backend, and one for the orchestrator in centralized mode).
 
-They can be pointed to any PostgreSQL instance:
+They can be pointed to any PostgreSQL instance
 
-
-Backend values:
+The backend and orchestrator use the same structure in their values:
 
 .. code-block:: yaml
-
    
    postgresql:
+     host: my.db.com
+     port: 5432
+     
      auth:
       username: my-user
       password: my-password
-      database: db-name
-      credentialsSecretName: secret-name # recommended rather than username/password
+      database: my-substra-db
 
-Orchestrator values (in standalone mode, which is the default):
+Or, for improved security, you can create a secret with your database credentials, under the ``POSTGRESQL_PASSWORD`` and ``POSTGRESQL_USERNAME`` keys:
 
 .. code-block:: yaml
+   
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: my-db-secret
+   type: Opaque
+   stringData:
+     POSTGRESQL_PASSWORD: my-password
+     POSTGRESQL_USERNAME: username
 
+And then point to it in the values, instead of using username & password:
+
+.. code-block:: yaml
+   
    postgresql:
+     host: my.db.com
+     port: 5432
+     
      auth:
-      username: my-user
-      password: my-password
-      database: db-name
+      database: my-substra-db
+      credentialsSecretName: my-db-secret

--- a/docs/source/operations/howto/external-database.rst
+++ b/docs/source/operations/howto/external-database.rst
@@ -1,0 +1,30 @@
+************************
+Use an external database
+************************
+
+By default, Substra components use their own integrated postgres databases (one per backend, and one for the orchestrator in centralized mode).
+
+They can be pointed to any PostgreSQL instance:
+
+
+Backend values:
+
+.. code-block:: yaml
+
+   
+   postgresql:
+     auth:
+      username: my-user
+      password: my-password
+      database: db-name
+      credentialsSecretName: secret-name # recommended rather than username/password
+
+Orchestrator values (in standalone mode, which is the default):
+
+.. code-block:: yaml
+
+   postgresql:
+     auth:
+      username: my-user
+      password: my-password
+      database: db-name

--- a/docs/source/operations/howto/external-database.rst
+++ b/docs/source/operations/howto/external-database.rst
@@ -4,22 +4,22 @@ Use an external database
 
 By default, Substra components use their own integrated postgres databases (one per backend, and one for the orchestrator in centralized mode).
 
-They can be pointed to any PostgreSQL instance
+They can be pointed to any PostgreSQL instance (version 11 or better).
 
 The backend and orchestrator use the same structure in their values:
 
 .. code-block:: yaml
    
-   postgresql:
+   database:
      host: my.db.com
      port: 5432
      
      auth:
-      username: my-user
+      username: my-username
       password: my-password
       database: my-substra-db
 
-Or, for improved security, you can create a secret with your database credentials, under the ``POSTGRESQL_PASSWORD`` and ``POSTGRESQL_USERNAME`` keys:
+Or, for improved security, you can create a secret with your database credentials, under the ``DATABASE_PASSWORD`` and ``DATABASE_USERNAME`` keys. Secrets can be `made very secure <https://kubernetes.io/docs/concepts/security/secrets-good-practices/>`_ but this is the basic example:
 
 .. code-block:: yaml
    
@@ -27,16 +27,15 @@ Or, for improved security, you can create a secret with your database credential
    kind: Secret
    metadata:
      name: my-db-secret
-   type: Opaque
    stringData:
-     POSTGRESQL_PASSWORD: my-password
-     POSTGRESQL_USERNAME: username
+     DATABASE_PASSWORD: my-password
+     DATABASE_USERNAME: my-username
 
 And then point to it in the values, instead of using username & password:
 
 .. code-block:: yaml
    
-   postgresql:
+   database:
      host: my.db.com
      port: 5432
      


### PR DESCRIPTION
Add a how-to page on using an external database.

The new page is called `external-database` but maybe it should just be `external-data` since we might put the external S3 instructions on there as well (once that's done).

Companion PRs:
 - https://github.com/Substra/orchestrator/pull/210
 - https://github.com/Substra/substra-backend/pull/658

Fixes FL-649