### PR TITLE
fix(docs): remove reference to absent CLI document

### DIFF
--- a/docs/source/documentation/api_reference.rst
+++ b/docs/source/documentation/api_reference.rst
@@ -3,13 +3,6 @@ API reference
 
 `substra` version: |substra_version|
 
-CLI Reference
--------------
-.. toctree::
-    :maxdepth: 2
-
-    references/cli.md
-
 SDK Reference
 -------------
 .. toctree::


### PR DESCRIPTION
CLI? What's that?