### PR TITLE
docs: add upgrade notes for 0.28

### DIFF
--- a/docs/source/additional/release.rst
+++ b/docs/source/additional/release.rst
@@ -61,7 +61,7 @@ Substra 0.28.0 --- 2023-06-14
 
 **Operations**:
 
-- Substra backend and orchestrator can now use **external database** rather having to use the one packaged as a subchart.
+- **BREAKING CHANGE**: Substra backend and orchestrator can now use **external database** rather having to use the one packaged as a subchart. See :ref:`upgrade notes <ops upgrade notes 0.28>`.
 
 Substra 0.27.0 --- 2023-05-11
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/operations/howto/external-database.rst
+++ b/docs/source/operations/howto/external-database.rst
@@ -1,3 +1,5 @@
+.. _ops howto external database:
+
 ************************
 Use an external database
 ************************

--- a/docs/source/operations/upgrade-notes.rst
+++ b/docs/source/operations/upgrade-notes.rst
@@ -14,6 +14,7 @@ This version now allows :ref:`external database connections <ops howto external 
 If you changed some database settings such as credentials in the orchestrator or backend values, like this:
 
 .. code:: yaml
+
    postgresql:
      auth:
       username: my-username
@@ -23,6 +24,7 @@ If you changed some database settings such as credentials in the orchestrator or
 Then you'll need to copy them over to a new ``database`` key:
 
 .. code-block:: yaml
+
    postgresql:
      auth:
       username: my-username

--- a/docs/source/operations/upgrade-notes.rst
+++ b/docs/source/operations/upgrade-notes.rst
@@ -4,6 +4,38 @@
 Upgrade notes
 *************
 
+.. _ops upgrade notes 0.28:
+
+Substra 0.28.0
+--------------
+
+This version now allows :ref:`external database connections <ops howto external database>`, and database setup info and connection info are no longer the same setting.
+
+If you changed some database settings such as credentials in the orchestrator or backend values, like this:
+
+.. code:: yaml
+   postgresql:
+     auth:
+      username: my-username
+      password: my-password
+      database: my-substra-db
+
+Then you'll need to copy them over to a new ``database`` key:
+
+.. code-block:: yaml
+   postgresql:
+     auth:
+      username: my-username
+      password: my-password
+      database: my-substra-db
+   
+   database:
+     auth:
+      username: my-username
+      password: my-password
+      database: my-substra-db
+      # you could also use YAML anchors for this
+
 Substra 0.23.1
 --------------
 


### PR DESCRIPTION
I just realized (a bit late) that actually the upgrade could break existing installations in some conditions. This PR adds upgrade notes to address this.