### PR TITLE
chore: use `Client.wait_compute_plan`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add `shared state` and `local state` definition in SubstraFL overview ([#321](https://github.com/Substra/substra-documentation/pull/321))
 - add `rank` definition in the Substra concepts ([#321](https://github.com/Substra/substra-documentation/pull/321))
 - Add experiment name for SubstraFL example ([#323](https://github.com/Substra/substra-documentation/pull/323))
+- Use `Client.wait_compute_plan` in `substrafl_examples/get_started/run_mnist_torch.py` ([#327](https://github.com/Substra/substra-documentation/pull/327))
 
 
 ## [0.28.0]

--- a/substrafl_examples/get_started/run_mnist_torch.py
+++ b/substrafl_examples/get_started/run_mnist_torch.py
@@ -474,8 +474,6 @@ compute_plan = execute_experiment(
 # Explore the results
 # *******************
 
-import time
-
 # The results will be available once the compute plan is completed
 client_0.wait_compute_plan(compute_plan.key)
 # %%

--- a/substrafl_examples/get_started/run_mnist_torch.py
+++ b/substrafl_examples/get_started/run_mnist_torch.py
@@ -476,6 +476,7 @@ compute_plan = execute_experiment(
 
 import time
 
+# The results will be available once the compute plan is completed
 client_0.wait_compute_plan(compute_plan.key)
 # %%
 # List results

--- a/substrafl_examples/get_started/run_mnist_torch.py
+++ b/substrafl_examples/get_started/run_mnist_torch.py
@@ -476,12 +476,7 @@ compute_plan = execute_experiment(
 
 import time
 
-# if we are using remote clients, we have to wait until the compute plan is done before getting the results
-while (
-    client_0.get_compute_plan(compute_plan.key).status == "PLAN_STATUS_DOING"
-    or client_0.get_compute_plan(compute_plan.key).status == "PLAN_STATUS_TODO"
-):
-    time.sleep(2)
+client_0.wait_compute_plan(compute_plan.key)
 # %%
 # List results
 # ============


### PR DESCRIPTION
## Related issue

- https://github.com/Substra/substra/pull/368
- https://github.com/Substra/substrafl/pull/147
- https://github.com/Substra/substra-tests/pull/263
- https://github.com/Substra/substra-documentation/pull/327

## Summary

Centralize `wait_task` and `wait_compute_plan`, and re-use the implementation added in `substra` through the other components.

## Notes

Fixes FL-1052

## Please check if the PR fulfills these requirements

- [x] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
