### PR TITLE
docs: fix typo in SSO documentation

### DIFF
--- a/docs/source/operations/howto/sso-oidc.rst
+++ b/docs/source/operations/howto/sso-oidc.rst
@@ -35,6 +35,7 @@ Set up user creation
 When a user first logs in through OIDC, they are assigned a username based on their email address. The ``oidc.users.appendDomain`` flag controls whether email domain is included.
 
 You must choose one user creation process:
+
 * Set up a default channel by setting ``oidc.users.channel`` to the name of an existing channel (see the value of ``orchestrator.channels``). OIDC users will be able to use the platform right away.
 * Alternatively, set ``oidc.users.requireApproval`` to ``true``: after their first login, OIDC users will have to wait for manual approval from an administrator (on the web frontend).
 


### PR DESCRIPTION
Signed-off-by: Romain Goussault <romain.goussault@owkin.com>

The bullet points were not properly displayed.

Before:
<img width="789" alt="image" src="https://github.com/Substra/substra-documentation/assets/5354301/5fe16562-42a9-4e1c-8b4a-271495db1302">


After:
<img width="759" alt="image" src="https://github.com/Substra/substra-documentation/assets/5354301/d8574f4e-e928-4185-9327-3ff308d84553">
