### PR TITLE
docs: expand the token generation how-to

### DIFF
--- a/docs/source/documentation/api_tokens_generation.rst
+++ b/docs/source/documentation/api_tokens_generation.rst
@@ -1,7 +1,10 @@
-How-to generate new API tokens for login
-========================================
+How-to use new API tokens for login
+===================================
 
-This short guide explains how to use the API tokens management page in the web application.
+This short guide explains how to manage API tokens in the web application, and use them in the Substra SDK.
+
+.. note::
+   API tokens are node-specific: if your script connects to multiple nodes, generate a token for each of them.
 
 Generating new API tokens
 -------------------------
@@ -15,7 +18,7 @@ You can also navigate to the page using the user menu:
 .. image:: /documentation/images/find_token_management_page.png
 
 
-Clicking on the ``Generate new``` button opens a menu allowing you to pick a name and an expiration date for
+Clicking ``Generate new`` opens a menu allowing you to pick a name and an expiration date for
 your new token. 
 
 
@@ -27,9 +30,25 @@ Afterward your token will be shown only once. Do copy it somewhere safe before p
 
 .. image:: /documentation/images/copy_token.png
 
+Using API tokens
+----------------
+
+Pass tokens to the `substra.Client <references/sdk.html#client>`_ constructor:
+
+.. code-block:: Python
+    :caption: Example of client configuration in code
+
+    client_1 = substra.Client(
+        backend_type="remote",
+        url="https://org-1.com",
+        token="dad943c684f65633635f005b2522a6452d20",
+    )
+
+See :ref:`client configuration howto` for other options.
 
 Deleting API tokens
 -------------------
 
-Every token can be deleted using the web application. Do be careful, token deletion is irreversible.
-If you have scripts using this deleted token, they will no longer execute. 
+Tokens can be deleted using the web application. Be careful, token deletion is irreversible.
+
+If you have scripts using a deleted token, they will no longer execute.

--- a/docs/source/documentation/client_configuration.rst
+++ b/docs/source/documentation/client_configuration.rst
@@ -1,3 +1,5 @@
+.. _client configuration howto:
+
 How-to configure Substra clients
 ================================
 


### PR DESCRIPTION
https://github.com/Substra/substra/pull/378 makes the token generation how-to into a landing page for annoyed data scientists. This PR therefore expands it a bit, so it can better solve the problem immediately without having to browse through the documentation.