### PR TITLE
docs: add a note arguing you should generate tokens

### DIFF
--- a/docs/source/how-to/using-substra/api_tokens_generation.rst
+++ b/docs/source/how-to/using-substra/api_tokens_generation.rst
@@ -11,13 +11,13 @@ This short guide explains how to manage API tokens in the web application, and u
    
    * doesn't allow for a precise lifetime or separating concerns by creating one token per purpose
    
-   * may surprise or limite you through its underlying automated session management
+   * may surprise or limit you through its underlying automated session management
    
    * can encourage using cleartext passwords, which can end up shared in version control.
    
    For these reasons, it is possible for Substra node administrators to disable "implicit login" and force users to generate tokens in the web app.
    
-   Whatever the situation, you should use a mechanism to ensure credentials are kept out of view, for instance by reading secret files or environment variables at runtime.
+   Whatever the situation, you should use a mechanism to ensure credentials are kept out of view, for instance by reading secret files or environment variables at runtime (see :ref:`client configuration howto`)
    
 
 .. warning::

--- a/docs/source/how-to/using-substra/api_tokens_generation.rst
+++ b/docs/source/how-to/using-substra/api_tokens_generation.rst
@@ -7,17 +7,17 @@ This short guide explains how to manage API tokens in the web application, and u
 
    The Substra SDK provides a way to log in using username and password (see `substra.Client <references/sdk.html#client>`_).
    
-   It is safe, but should be used with caution, as it:
+   It is safe, but should be used with caution:
    
-   * doesn't allow for a precise lifetime or separating concerns by creating one token per purpose
+   * It doesn't allow for a precise lifetime or separating concerns by creating one token per purpose.
    
-   * may surprise or limit you through its underlying automated session management
+   * It may surprise or limit you through its underlying automated session management.
    
-   * can encourage using cleartext passwords, which can end up shared in version control.
+   * It can encourage using cleartext passwords, which can end up shared in version control.
    
    For these reasons, it is possible for Substra node administrators to disable "implicit login" and force users to generate tokens in the web app.
    
-   Whatever the situation, you should use a mechanism to ensure credentials are kept out of view, for instance by reading secret files or environment variables at runtime (see :ref:`client configuration howto`)
+   Whatever the situation, you should use a mechanism to ensure credentials are kept out of view, for instance by reading secret files or environment variables at runtime (see :ref:`client configuration howto`).
    
 
 .. warning::

--- a/docs/source/how-to/using-substra/api_tokens_generation.rst
+++ b/docs/source/how-to/using-substra/api_tokens_generation.rst
@@ -3,7 +3,24 @@ How-to use new API tokens for login
 
 This short guide explains how to manage API tokens in the web application, and use them in the Substra SDK.
 
-.. note::
+.. admonition:: Why generate API tokens?
+
+   The Substra SDK provides a way to log in using username and password (see `substra.Client <references/sdk.html#client>`_).
+   
+   It is safe, but should be used with caution, as it:
+   
+   * doesn't allow for a precise lifetime or separating concerns by creating one token per purpose
+   
+   * may surprise or limite you through its underlying automated session management
+   
+   * can encourage using cleartext passwords, which can end up shared in version control.
+   
+   For these reasons, it is possible for Substra node administrators to disable "implicit login" and force users to generate tokens in the web app.
+   
+   Whatever the situation, you should use a mechanism to ensure credentials are kept out of view, for instance by reading secret files or environment variables at runtime.
+   
+
+.. warning::
    API tokens are node-specific: if your script connects to multiple nodes, generate a token for each of them.
 
 Generating new API tokens

--- a/docs/source/how-to/using-substra/api_tokens_generation.rst
+++ b/docs/source/how-to/using-substra/api_tokens_generation.rst
@@ -15,7 +15,7 @@ This short guide explains how to manage API tokens in the web application, and u
    
    * It can encourage using cleartext passwords, which can end up shared in version control.
    
-   For these reasons, it is possible for Substra node administrators to disable "implicit login" and force users to generate tokens in the web app.
+   For these reasons, it is possible for Substra node administrators (via `chart options <https://github.com/Substra/substra-backend/blob/main/charts/substra-backend/README.md#server-settings>`_) to disable "implicit login" and force users to generate tokens in the web app.
    
    Whatever the situation, you should use a mechanism to ensure credentials are kept out of view, for instance by reading secret files or environment variables at runtime (see :ref:`client configuration howto`).
    


### PR DESCRIPTION
Add a note at the top of the token generation howto, explaining why you should, what you should do if you don't, and that administrators can disable it.

I'd like to add a link to the proper helm chart value in that last item, but I don't really know what to link to (the value is `server.allowImplicitLogin`.

Companion PR to https://github.com/Substra/substra-backend/pull/698

Similar to https://github.com/Substra/substra-documentation/pull/335 and https://github.com/Substra/substra/pull/378