### PR TITLE
docs: standardize capitalization

### DIFF
--- a/docs/source/additional/release.rst
+++ b/docs/source/additional/release.rst
@@ -398,7 +398,7 @@ become
   if __name__ == '__main__':
     tools.execute()
 
-Substra Backend:
+Substra backend:
 
 - Prevent use of ``__`` in asset metadata keys
 

--- a/docs/source/documentation/backend/index.rst
+++ b/docs/source/documentation/backend/index.rst
@@ -24,10 +24,10 @@ postgresql
 redis
     This is an organization-specific message broker to support `Celery`_ tasks.
 backend-events
-    This component will consume events from the Orchestrator.
-    It should be able to access the Orchestrator over gRPC.
+    This component will consume events from the orchestrator.
+    It should be able to access the orchestrator over gRPC.
     It handles events and triggers appropriate responses such as starting compute tasks.
-    On startup, it will also register the Organization on the Orchestrator.
+    On startup, it will also register the Organization on the orchestrator.
 migrations
     This Pod is managed by a Job running on chart installation or update to deal with database schema changes.
     This Pod also performs user creation.
@@ -48,7 +48,7 @@ worker
 Communication
 =============
 
-The backend should be able to reach its Orchestrator.
+The backend should be able to reach its orchestrator.
 If :term:`Organizations<Organization>` share :ref:`Models<concept_model>`, involved backends must be able to communicate with each other.
 
 Helm chart

--- a/docs/source/documentation/components.rst
+++ b/docs/source/documentation/components.rst
@@ -1,7 +1,7 @@
 Components
 ==========
 
-We distinguish two major components, the orchestrator and the Backend.
+We distinguish two major components, the orchestrator and the backend.
 Although they are independent, their versions must match a tested release as referenced in the :ref:`compatibility table <compatibility table>`.
 
 .. image:: ../static/schemes/stack-technical-scheme.svg

--- a/docs/source/documentation/components.rst
+++ b/docs/source/documentation/components.rst
@@ -1,7 +1,7 @@
 Components
 ==========
 
-We distinguish two major components, the Orchestrator and the Backend.
+We distinguish two major components, the orchestrator and the Backend.
 Although they are independent, their versions must match a tested release as referenced in the :ref:`compatibility table <compatibility table>`.
 
 .. image:: ../static/schemes/stack-technical-scheme.svg

--- a/docs/source/documentation/frontend/index.rst
+++ b/docs/source/documentation/frontend/index.rst
@@ -18,7 +18,7 @@ Communication
 =============
 
 The frontend should be able to reach its backend through the REST API.
-The access to the API is secured through the use of Json Web Tokens (JWT), which are stored through cookies. Each backend server pod has its own token, so when working with different backends or restarting pods, it might be necessary to delete related cookies (namely signature, refresh and header.payload) so a new JWT can be created. Otherwise this could block you from logging into the frontend.   
+The access to the API is secured through the use of JSON Web Tokens (JWT), which are stored through cookies. Each backend server pod has its own token, so when working with different backends or restarting pods, it might be necessary to delete related cookies (namely signature, refresh and header.payload) so a new JWT can be created. Otherwise this could block you from logging into the frontend.   
 
 Helm chart
 ==========

--- a/docs/source/documentation/orchestrator/index.rst
+++ b/docs/source/documentation/orchestrator/index.rst
@@ -28,7 +28,7 @@ Communication
 .. for now let's ignore distributed mode
 
 The orchestrator is a central component.
-All Backends from each :term:`Organization` must have access to the orchestrator over gRPC for command/queries and event subsription.
+All backends from each :term:`Organization` must have access to the orchestrator over gRPC for command/queries and event subsription.
 
 The orchestrator authenticates clients with their TLS certificates.
 As a consequence, the Kubernetes Ingress must do SSL passthrough.

--- a/docs/source/how-to/deploying-substra/walkthrough/20-orchestrator-deployment.rst
+++ b/docs/source/how-to/deploying-substra/walkthrough/20-orchestrator-deployment.rst
@@ -25,7 +25,7 @@ Prepare your Helm values
         enabled: true
         hostname: orchestrator.cluster-1.DOMAIN
 
-   | This sets up the ingress to make your Orchestrator accessible at the defined hostname.
+   | This sets up the ingress to make your orchestrator accessible at the defined hostname.
 
 .. _orchestrator-channel-config:
 
@@ -53,7 +53,7 @@ Here we will generate them manually but you can also use automated tools for thi
 If you want to use automated tools we provide a certificate resource for `cert-manager <https://cert-manager.io/>`_.
 The ``orchestrator.tls.createCertificates`` values should be a good place for you to get started.
 
-The Orchestrator needs to handle SSL termination for this to work.
+The orchestrator needs to handle SSL termination for this to work.
 You may need to adapt your proxy configuration to let the traffic go through it.
 For example if you use ``ingress-nginx`` you may want to read the `ssl passthrough <https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough>`_ chapter of their documentation.
 
@@ -100,7 +100,7 @@ To setup TLS, follow these steps:
 
         openssl req -new -x509 -days 365 -sha256 -key orchestrator-ca.key -extensions v3_ca -config example-openssl.cnf -subj "/CN=Orchestrator Root CA" -out orchestrator-ca.crt
 
-#. Generate a certificate for the Orchestrator
+#. Generate a certificate for the orchestrator
 
    #. Generate a certificate signing request:
 
@@ -147,7 +147,7 @@ Deploy the Chart
 
 To deploy the orchestrator in your Kubernetes cluster follow these steps:
 
-#. Deploy the Orchestrator Helm chart:
+#. Deploy the orchestrator Helm chart:
 
    .. code-block:: bash
 
@@ -170,5 +170,5 @@ To deploy the orchestrator in your Kubernetes cluster follow these steps:
 
       Failed to list services: rpc error: code = Unknown desc = OE0003: missing or invalid header 'mspid'
 
-   This is expected because the Orchestrator server expects some gRPC headers to be present but we did not provide them.
+   This is expected because the orchestrator server expects some gRPC headers to be present but we did not provide them.
    Even if it is an error, since this response is from the server it is sufficient to tell your setup is working.

--- a/docs/source/how-to/deploying-substra/walkthrough/30-backend-deployment.rst
+++ b/docs/source/how-to/deploying-substra/walkthrough/30-backend-deployment.rst
@@ -71,11 +71,11 @@ To configure your values:
    | ``restricted`` would prevent other organizations from joining the channel
    | ``model_export_enabled`` allows users from this channel to download models produced by the platform
 
-#. Optional: If your Orchestrator has TLS enabled:
+#. Optional: If your orchestrator has TLS enabled:
 
    #. Retrieve the CA certificate from your orchestrator:
 
-      The CA certificate is the ``orchestrator-ca.crt`` file generated at the :ref:`Generate your Certificate Authority certificate <orchestrator-cacert-generation>` step of the Orchestrator deployment.
+      The CA certificate is the ``orchestrator-ca.crt`` file generated at the :ref:`Generate your Certificate Authority certificate <orchestrator-cacert-generation>` step of the orchestrator deployment.
       If a public Certificate Authority was used to generate the orchestrator certificate, you need to fetch the certificate of the Certificate Authority.
 
    #. Create a ConfigMap containing the CA certificate:
@@ -84,7 +84,7 @@ To configure your values:
 
          kubectl create configmap orchestrator-cacert --from-file=ca.crt=orchestrator-ca.crt
 
-   #. Configure your backend to enable Orchestrator TLS. In the ``backend-ingen-values.yaml`` file add the following content under the ``orchestrator`` key:
+   #. Configure your backend to enable orchestrator TLS. In the ``backend-ingen-values.yaml`` file add the following content under the ``orchestrator`` key:
 
       .. code-block:: yaml
 

--- a/docs/source/how-to/deploying-substra/walkthrough/40-connect-organizations.rst
+++ b/docs/source/how-to/deploying-substra/walkthrough/40-connect-organizations.rst
@@ -29,7 +29,7 @@ Configure matching values for your 2 :term:`Organizations <Organization>`:
             channel: our-channel
 
    | ``SECRET_ORG1_ORG2`` is a password ``biotechnica`` needs to download assets from ``ingen``.
-   | ``our-channel`` was defined in the :ref:`Backend channel configuration <backend-channel-config>` -- both ``ingen`` and ``biotechnica`` are members of it.
+   | ``our-channel`` was defined in the :ref:`backend channel configuration <backend-channel-config>` -- both ``ingen`` and ``biotechnica`` are members of it.
 
 #. Create an account for ``ingen`` on ``biotechnica``.
    In ``backend-biotechnica-values.yaml`` add the following content:


### PR DESCRIPTION
I noticed https://github.com/Substra/substra-documentation/pull/348 used `orchestrator` (not capitalized) to match `backend`, which I fully agree with since "orchestrator" is a foremost a role, just like "backend"; this spreads the change to all the documentation for consistency.