### PR TITLE
docs: Rename titles

### DIFF
--- a/docs/source/documentation/concepts.rst
+++ b/docs/source/documentation/concepts.rst
@@ -1,5 +1,5 @@
-Main Substra concepts
-=====================
+Substra overview
+================
 
 .. concepts:
 

--- a/docs/source/how-to/using-substra/get_performances.rst
+++ b/docs/source/how-to/using-substra/get_performances.rst
@@ -1,5 +1,5 @@
-Performance monitoring in local mode
-====================================
+How to monitor performance in local mode
+========================================
 
 Performances of a compute plan can be retrieved
 - with the :code:`get_performances(CP_KEY)` function of the `Substra Python library <api_reference.html#sdk-reference>`_

--- a/docs/source/how-to/using-substra/gpu.rst
+++ b/docs/source/how-to/using-substra/gpu.rst
@@ -1,5 +1,5 @@
-GPU usage
-=========
+How to leverage GPU
+===================
 
 Substra can leverage GPU to speed up the training of machine learning models. Find below how to configure Substra to make sure your code can run on GPU.
 


### PR DESCRIPTION
Rename title to bring more harmony to the docs.

Signed-off-by: Romain Goussault <romain.goussault@owkin.com>