### PR TITLE
chore: release 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Revamp landing page ([#353](https://github.com/Substra/substra-documentation/pull/353))
+## [0.31.0]
+
 - Add user management doc ([#345](https://github.com/Substra/substra-documentation/pull/345))
 - Add link to python libraries documentation in Components page ([#347](https://github.com/Substra/substra-documentation/pull/347))
 - Add more orchestrator documentation ([#346](https://github.com/Substra/substra-documentation/pull/346))
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added section about channels in the main concepts ([#344](https://github.com/Substra/substra-documentation/pull/344))
 - Add frontend documentation in components section ([#346](https://github.com/Substra/substra-documentation/pull/346))
 - New page added on Substra Privacy Strategy based on research by Privacy Task Force at Owkin ([#354](https://github.com/Substra/substra-documentation/pull/354))
+- Revamp landing page ([#353](https://github.com/Substra/substra-documentation/pull/353))
 
 ## [0.30.0]
 

--- a/docs/source/additional/release.rst
+++ b/docs/source/additional/release.rst
@@ -28,6 +28,50 @@ This is an overview of the main changes, please have a look at the changelog of 
 - `backend changelog <https://github.com/Substra/substra-backend/blob/main/CHANGELOG.md>`__
 - `orchestrator changelog <https://github.com/Substra/orchestrator/blob/main/CHANGELOG.md>`__
 
+Substra 0.31.0 --- 2023-09-07
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**SubstraFL:**
+
+- **BREAKING**: `local_dependencies` is renamed `local_installable_dependencies`.
+- Python dependencies can be resolved using pip compile during function registration by setting `compile` to `True` in the `Dependency` object. This will speed-up the docker image build phase when running on a Substra server but will slow down a bit the compute plan registration.
+    
+  .. code-block:: python
+
+    Dependency(
+      pypi_dependencies=["pytest", "numpy"],
+      compile=True,
+    )
+    
+- `random.seed` , `np.random.seed` and `torch.manual_seed`  are now set, saved & load in `TorchAlgo`
+- When using `clean_models=True`, the tasks outputs of the very last round are now saved.****
+
+**Substra**:
+
+- Added  `wait_completion` parameter on `get_performances`, `list_task_output_assets` and `get_task_output_asset` to block execution until task execution is over.
+- On Client login:
+    - Fixes issue where the session would not actually last the 24 hours intended.
+    - Added new `Client.logout` function, mirroring `Client.login`
+    - `Client` can now be used within a context manager
+    
+    .. code-block:: python
+
+      with Client(
+        client_name="org-1",
+        backend_type="remote",
+        url="http://substra-backend.org-1.com:8000",
+        username="org-1",
+        password="p@sswr0d44",
+      ) as client:
+        pass
+
+**Web application**
+
+- Fix issue where cancel CP button was not usable on workflow page
+- Task duration displayed in task drawer and not only the start and end time.
+- Increase the number of tasks displayable in frontend workflow from 1000 to 5000 tasks
+
+
 Substra 0.30.0 --- 2023-07-27
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/additional/releases.yaml
+++ b/docs/source/additional/releases.yaml
@@ -9,6 +9,44 @@ components: # for table headers
   - substra-tests
 
 releases:
+  - version: 0.31.0
+    components:
+      substrafl:
+        version: 0.40.0
+        link: https://github.com/Substra/substrafl/releases/tag/0.40.0
+      substra:
+        version: 0.47.0
+        link: https://github.com/Substra/substra/releases/tag/0.47.0
+      substra-tools:
+        version: 0.20.0
+        link: https://github.com/Substra/substra-tools/releases/tag/0.20.0
+      substra-backend:
+        version: 0.41.0
+        link: https://github.com/Substra/substra-backend/releases/tag/0.41.0
+        helm:
+          version: 22.8.1
+          link: https://artifacthub.io/packages/helm/substra/substra-backend/22.8.1
+      orchestrator:
+        version: 0.36.0
+        link: https://github.com/Substra/orchestrator/releases/tag/0.36.0
+        helm:
+          version: 7.5.4
+          link: https://artifacthub.io/packages/helm/substra/orchestrator/7.5.4
+      substra-frontend:
+        version: 0.45.0
+        link: https://github.com/Substra/substra-frontend/releases/tag/0.45.0
+        helm:
+          version: 1.0.23
+          link: https://artifacthub.io/packages/helm/substra/substra-frontend/1.0.23
+      hlf-k8s:
+        version: 0.2.4
+        link: https://github.com/Substra/hlf-k8s/releases/tag/0.2.4
+        helm:
+          version: 10.2.4
+          link: https://artifacthub.io/packages/helm/substra/hlf-k8s/10.2.4
+      substra-tests:
+        version: 0.44.0
+        link: https://github.com/Substra/substra-tests/releases/tag/0.44.0
   - version: 0.30.0
     components:
       substrafl:


### PR DESCRIPTION
- Add user management doc ([#345](https://github.com/Substra/substra-documentation/pull/345))
- Add link to python libraries documentation in Components page ([#347](https://github.com/Substra/substra-documentation/pull/347))
- Add more orchestrator documentation ([#346](https://github.com/Substra/substra-documentation/pull/346))
- Deactivate Binder ([#340](https://github.com/Substra/substra-documentation/pull/340))
- Reorganise documentation according to [diataxis](https://diataxis.fr/) approach ([#330](https://github.com/Substra/substra-documentation/pull/330))
- Added section about channels in the main concepts ([#344](https://github.com/Substra/substra-documentation/pull/344))
- Add frontend documentation in components section ([#346](https://github.com/Substra/substra-documentation/pull/346))
- New page added on Substra Privacy Strategy based on research by Privacy Task Force at Owkin ([#354](https://github.com/Substra/substra-documentation/pull/354))
- Revamp landing page ([#353](https://github.com/Substra/substra-documentation/pull/353))