### PR TITLE
chore: update k3s_create.sh to allow third organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `k3s_create.sh`` file, needed for a local deployment ([#365](https://github.com/Substra/substra-documentation/pull/365))
+
 ## [0.32.0]
 
 - No changes.

--- a/docs/source/how-to/developing-substra/local-deployment/k3-create.sh
+++ b/docs/source/how-to/developing-substra/local-deployment/k3-create.sh
@@ -10,14 +10,15 @@ fi
 k3d cluster delete || echo 'No cluster'
 mkdir -p /tmp/org-1
 mkdir -p /tmp/org-2
-k3d cluster create --api-port 127.0.0.1:6443 -p 80:80@loadbalancer -p 443:443@loadbalancer --k3s-arg "--disable=traefik,metrics-server@server:*" --volume /tmp/org-1:/tmp/org-1 --volume /tmp/org-2:/tmp/org-2
+mkdir -p /tmp/org-3
+k3d cluster create --api-port 127.0.0.1:6443 -p 80:80@loadbalancer -p 443:443@loadbalancer --k3s-arg "--disable=traefik,metrics-server@server:*" --volume /tmp/org-1:/tmp/org-1 --volume /tmp/org-2:/tmp/org-2 --volume /tmp/org-3:/tmp/org-3
 
 # Patch and install nginx-ingress
 curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml > /tmp/deploy.yaml
 $SED_EXEC -i 's/        - --publish-status-address=localhost/        - --publish-status-address=localhost\n        - --enable-ssl-passthrough/g' /tmp/deploy.yaml
 $SED_EXEC -i "/ingress-ready: \"true\"/d" /tmp/deploy.yaml
 kubectl apply -f /tmp/deploy.yaml
-
 kubectl create ns orderer
 kubectl create ns org-1
 kubectl create ns org-2
+kubectl create ns org-3


### PR DESCRIPTION
## Description

Propose a Skaffold profile to create 3 orgs in standalone mode.
This profile is called "three_orgs".

## How has this been tested?

CI + Locally

## Companion

- https://github.com/Substra/substra-backend/pull/733
- https://github.com/Substra/orchestrator/pull/280
- https://github.com/Substra/substra-documentation/pull/365
