### PR TITLE
fix(docs/source/additional/release): link to json release table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `k3s_create.sh` file, needed for a local deployment ([#365](https://github.com/Substra/substra-documentation/pull/365))
 - Add files to run documentation examples in nightly CI ([#357](https://github.com/Substra/substra-documentation/pull/357))
 - Update example to be runnable in remote mode ([#357](https://github.com/Substra/substra-documentation/pull/357))
+- Fix [JSON releases](https://docs.substra.org/releases.json) ([#356](https://github.com/Substra/substra-documentation/pull/356))
 
 ### Added
 

--- a/docs/source/additional/release.rst
+++ b/docs/source/additional/release.rst
@@ -14,7 +14,10 @@ These sets of versions have been tested for compatibility:
 .. only:: html
 
    .. note::
-      `JSON version of the release table </releases.json>`_
+
+      .. /!\ Path to `docs/build/html/releases.json` is relative to `release.html`
+
+      `JSON version of the release table <../releases.json>`_
 
 Changelog
 ---------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,16 +29,12 @@ from sphinx_gallery.sorting import ExplicitOrder
 TMP_FOLDER = Path(__file__).parents[2] / "tmp"
 TMP_FOLDER.mkdir(exist_ok=True)
 
-# Generate a JSON compatibility table
-
-html_extra_path = []
+JSON_COMPATIBILITY_TABLE_FILE = TMP_FOLDER / "releases.json"
 
 with open("additional/releases.yaml") as f:
     compat_table = yaml.safe_load(f)
-    dest = Path(TMP_FOLDER, "releases.json")
-    with open(dest, "w") as f:
+    with open(JSON_COMPATIBILITY_TABLE_FILE, "w") as f:
         json.dump(compat_table, f)
-        html_extra_path.append(str(dest))
 
 repo = git.Repo(search_parent_directories=True)
 current_commit = repo.head.commit
@@ -402,6 +398,8 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["./static"]
+
+html_extra_path = [str(JSON_COMPATIBILITY_TABLE_FILE)]
 
 html_css_files = [
     "owkin.css",


### PR DESCRIPTION
# Issue

Hopefully closes FL-1124

# Changelog 

`docs/source/additional/releases.yaml` → `docs/source/additional/releases.json`

# (semi)Proof of (semi)Concept

For what it's worth... [build#366](https://owkin-substra-documentation--366.com.readthedocs.build/en/366/releases.json)