### PR TITLE
chore(docs): Add doc for task outputs permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support on Python 3.11 ([#367](https://github.com/Substra/substra-documentation/pull/367))
+- Add doc about task output permissions ([#369](https://github.com/Substra/substra-documentation/pull/369))
 
 ## [0.33.1]
 

--- a/docs/source/documentation/concepts.rst
+++ b/docs/source/documentation/concepts.rst
@@ -155,13 +155,13 @@ In the following tables, the asset is registered by orgA with the permissions:
      - What can the organization do?
      - Can the user of the organization export the asset?
    * - orgA
-     - orgA can see the result if the output is a performance
-     - Yes - if the ouput is a model
+     - orgA can see (for performances) or download (for models) the output
+     - Yes - the serialized output
    * - orgB
-     - orgB can see the result if the output is a performance
-     - Yes - if the ouput is a model
+     - orgB can see (for performances) or download (for models) the output
+     - Yes - the serialized output
    * - orgC
-     - Nothing - the performances results will be hidden
+     - Nothing
      - No
 
 

--- a/docs/source/documentation/concepts.rst
+++ b/docs/source/documentation/concepts.rst
@@ -147,6 +147,23 @@ In the following tables, the asset is registered by orgA with the permissions:
      - Nothing
      - No
 
+.. list-table:: Task outputs permissions
+   :widths: 5 50 50
+   :header-rows: 1
+
+   * - Organization
+     - What can the organization do?
+     - Can the user of the organization export the asset?
+   * - orgA
+     - orgA can see the result if the output is a performance
+     - Yes - if the ouput is a model
+   * - orgB
+     - orgB can see the result if the output is a performance
+     - Yes - if the ouput is a model
+   * - orgC
+     - Nothing - the performances results will be hidden
+     - No
+
 
 
 Parallelization

--- a/docs/source/substrafl_doc/substrafl_overview.rst
+++ b/docs/source/substrafl_doc/substrafl_overview.rst
@@ -216,3 +216,37 @@ Example of shared state for a :ref:`Federated Averaging <substrafl_doc/api/algor
             "n_sample": len(dataset),
             "parameter_update": parameters_update,
         }
+
+
+Task outputs permissions
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+For each kind of tasks there is different outputs with their own permissions. This section will describe the default permissions settings for each kind of task in the FedAvg example.
+Note that you can go and change these settings in the code if they don't fit your needs.
+
+Initialisation task
+*******************
+
+- local: Model type output. Permissions are available to the creator organization and the organizations with registered test dataset.
+- shared: Model type output. Permissions are available to the creator oganization, the organizations with registered test datasets and the organization handling aggregations.
+
+Train task
+**********
+
+- local: Model type output. Permissions are available to the creator organization and the organizations with registered test dataset.
+- shared: Model type output. Permissions are available to the creator oganization, the organizations with registered test datasets and the organization handling aggregations.
+
+Prediction task
+***************
+
+- prediction: Model type output. Permissions are only available to the creator organization.
+
+Test task
+**********
+
+- performance: Number type output. Permissions are public, available to all.
+
+Aggregation task
+****************
+
+- shared: Model type output. Permissions are available to organizations with train tasks. 

--- a/docs/source/substrafl_doc/substrafl_overview.rst
+++ b/docs/source/substrafl_doc/substrafl_overview.rst
@@ -221,32 +221,32 @@ Example of shared state for a :ref:`Federated Averaging <substrafl_doc/api/algor
 Task outputs permissions
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-For each kind of tasks there is different outputs with their own permissions. This section will describe the default permissions settings for each kind of task in the FedAvg example.
+For each kind of tasks there is different outputs with their own permissions. This section describes the default permissions settings for each kind of task in the **FedAvg strategy**, chosen as an example.
 Note that you can go and change these settings in the code if they don't fit your needs.
 
 Initialisation task
 *******************
 
-- local: Model type output. Permissions are available to the creator organization and the organizations with registered test dataset.
-- shared: Model type output. Permissions are available to the creator oganization, the organizations with registered test datasets and the organization handling aggregations.
+- ``local``: Model type output. Permissions are set to the organization that creates the task and the organizations with registered test dataset.
+- ``shared``: Model type output. Permissions are set to the organization that creates the task, the organizations with registered test datasets and the organization handling aggregations.
 
 Train task
 **********
 
-- local: Model type output. Permissions are available to the creator organization and the organizations with registered test dataset.
-- shared: Model type output. Permissions are available to the creator oganization, the organizations with registered test datasets and the organization handling aggregations.
+- ``local``: Model type output. Permissions are set to the organization that creates the task and the organizations with registered test dataset.
+- ``shared``: Model type output. Permissions are set to the organization that creates the task, the organizations with registered test datasets and the organization handling aggregations.
 
 Prediction task
 ***************
 
-- prediction: Model type output. Permissions are only available to the creator organization.
+- ``prediction``: Model type output. Permissions are only set to the organization that creates the task.
 
 Test task
 **********
 
-- performance: Number type output. Permissions are public, available to all.
+- ``performance``: Number type output. Permissions are public, set to all.
 
 Aggregation task
 ****************
 
-- shared: Model type output. Permissions are available to organizations with train tasks. 
+- ``shared``: Model type output. Permissions are set to organizations with train tasks. 


### PR DESCRIPTION
Add some docs on the default permissions settings for FedAvg and what the user can see in the front with/without permissions.

Closes FL-1174 