### PR TITLE
chore: support Python 3.12

### DIFF
--- a/.github/workflows/test-examples-subprocess.yml
+++ b/.github/workflows/test-examples-subprocess.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/changes/430.added
+++ b/changes/430.added
@@ -1,0 +1,1 @@
+Support Python 3.12.

--- a/docs/source/examples/substra_core/titanic_example/assets/function_random_forest/predict/Dockerfile
+++ b/docs/source/examples/substra_core/titanic_example/assets/function_random_forest/predict/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # install dependencies
 RUN pip3 install pandas 'numpy<2.0' 'scikit-learn==1.5.0' substratools

--- a/docs/source/examples/substra_core/titanic_example/assets/function_random_forest/train/Dockerfile
+++ b/docs/source/examples/substra_core/titanic_example/assets/function_random_forest/train/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # install dependencies
 RUN pip3 install pandas 'numpy<2.0' 'scikit-learn==1.5.0' substratools

--- a/docs/source/examples/substra_core/titanic_example/assets/metric/Dockerfile
+++ b/docs/source/examples/substra_core/titanic_example/assets/metric/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # install dependencies
 RUN pip3 install pandas 'numpy<2.0' 'scikit-learn==1.5.0' substratools

--- a/docs/source/substrafl_doc/substrafl_overview.rst
+++ b/docs/source/substrafl_doc/substrafl_overview.rst
@@ -22,7 +22,7 @@ Installation
 
 .. _installation:
 
-Substrafl and Substra are compatible with Python versions 3.9, 3.10 and 3.11 on Windows, MacOS and Linux.
+Substrafl and Substra are compatible with Python versions 3.9, 3.10, 3.11 and 3.12 on Windows, MacOS and Linux.
 
 .. note::
 


### PR DESCRIPTION
Adding support for Python 3.12, in particular in the CI.

Dropping 3.8 and 3.9 from the CI (both versions at the same time, since we forgot to do it last time).