### PR TITLE
chore: bump Pytorch version to 2.2.1 in examples

### DIFF
--- a/changes/431.fixed
+++ b/changes/431.fixed
@@ -1,0 +1,1 @@
+Bump pytorch version to 2.2.1 in tests.

--- a/docs/source/examples/substrafl/get_started/run_mnist_torch.ipynb
+++ b/docs/source/examples/substrafl/get_started/run_mnist_torch.ipynb
@@ -571,7 +571,7 @@
    "source": [
     "from substrafl.dependency import Dependency\n",
     "\n",
-    "dependencies = Dependency(pypi_dependencies=[\"numpy==1.26.4\", \"scikit-learn==1.5.0\", \"torch==2.0.1\", \"--extra-index-url https://download.pytorch.org/whl/cpu\"])"
+    "dependencies = Dependency(pypi_dependencies=[\"numpy==1.26.4\", \"scikit-learn==1.5.0\", \"torch==2.2.1\", \"--extra-index-url https://download.pytorch.org/whl/cpu\"])"
    ]
   },
   {

--- a/docs/source/examples/substrafl/get_started/torch_fedavg_assets/requirements.txt
+++ b/docs/source/examples/substrafl/get_started/torch_fedavg_assets/requirements.txt
@@ -3,5 +3,5 @@ numpy==1.26.4
 pandas==2.2.2
 scikit-learn==1.5.0
 substrafl
-torch==2.0.1
-torchvision==0.15.2
+torch==2.2.1
+torchvision==0.17.1

--- a/docs/source/examples/substrafl/go_further/run_mnist_cyclic.ipynb
+++ b/docs/source/examples/substrafl/go_further/run_mnist_cyclic.ipynb
@@ -919,7 +919,7 @@
    "source": [
     "from substrafl.dependency import Dependency\n",
     "\n",
-    "dependencies = Dependency(pypi_dependencies=[\"numpy==1.26.4\", \"scikit-learn==1.5.0\", \"torch==2.0.1\", \"--extra-index-url https://download.pytorch.org/whl/cpu\"])"
+    "dependencies = Dependency(pypi_dependencies=[\"numpy==1.26.4\", \"scikit-learn==1.5.0\", \"torch==2.2.1\", \"--extra-index-url https://download.pytorch.org/whl/cpu\"])"
    ]
   },
   {

--- a/docs/source/examples/substrafl/go_further/torch_cyclic_assets/requirements.txt
+++ b/docs/source/examples/substrafl/go_further/torch_cyclic_assets/requirements.txt
@@ -3,5 +3,5 @@ numpy==1.26.4
 pandas==2.2.2
 scikit-learn==1.5.0
 substrafl
-torch==2.0.1
-torchvision==0.15.2
+torch==2.2.1
+torchvision==0.17.1


### PR DESCRIPTION
Fixes CI